### PR TITLE
Update vale config in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Vale Style Package for Coop.
 Add a `.vale.ini` to your repository.
 
 ```ini title=".vale.ini"
-StylesPath = .vale/styles
+StylesPath = styles
 
 Packages = https://github.com/coopnorge/vale-coop/releases/latest/download/Coop.zip
 ```
@@ -15,7 +15,7 @@ Packages = https://github.com/coopnorge/vale-coop/releases/latest/download/Coop.
 Repository specific Configuration can also be added.
 
 ```ini title=".vale.ini"
-StylesPath = .vale/styles
+StylesPath = styles
 
 Packages = https://github.com/coopnorge/vale-coop/releases/latest/download/Coop.zip
 


### PR DESCRIPTION
According to: https://vale.sh/docs/topics/vocab/#folder-structure

`StylesPath = styles` - will automatically use `Vocab` as an entry, so the consumer will just define `Vocab = CoopTech, CoopTerms` etc