### PR TITLE
Add support for mkdocs-table-reader-plugin tokens

### DIFF
--- a/Coop/.vale.ini
+++ b/Coop/.vale.ini
@@ -4,5 +4,5 @@ StylesPath = styles
 Vocab = CoopGeneral, CoopTech, CoopCompanies, CoopAbbreviations, CoopPeople, CoopSystems, CoopLocations, CoopTerms
 
 [*.md]
-TokenIgnores = [\w][\w.]*@[\w*][\w.]*[\w], <https://.+>
+TokenIgnores = [\w][\w.]*@[\w*][\w.]*[\w], <https://.+>, {{\sread_.+\(.+\)\s}}
 BasedOnStyles = Vale


### PR DESCRIPTION
Vale must ignore tokens used by: https://timvink.github.io/mkdocs-table-reader-plugin/
