### PR TITLE
feat: Ignore tokens when they are in links or ref-links. 

### DIFF
--- a/Coop/.vale.ini
+++ b/Coop/.vale.ini
@@ -4,5 +4,5 @@ StylesPath = styles
 Vocab = CoopGeneral, CoopTech, CoopCompanies, CoopAbbreviations, CoopPeople, CoopSystems, CoopLocations, CoopTerms
 
 [*.md]
-TokenIgnores = [\w][\w.]*@[\w*][\w.]*[\w], <https://.+>, {{\sread_.+\(.+\)\s}}
+TokenIgnores = [\w][\w.]*@[\w*][\w.]*[\w], <https://.+>, {{\sread_.+\(.+\)\s}}, \[.+\]\(.+\), \[.+\]\[.+\]
 BasedOnStyles = Vale

--- a/docs/test.md
+++ b/docs/test.md
@@ -1,0 +1,24 @@
+# Testing of vale
+
+The following examples should all pass Techdocs-validation, even though `IDP`
+should normally be capitalized:
+
+Example using IDP capitalized.
+
+Example using [#team-idp](https://www.coop.no/) lowercase in a link.
+
+Example using [#team-idp][idp-ref-link] lowercase in a ref-link.
+
+Example using <https://idp> lowercase in a angle-bracket link.
+
+Example using `idp` lowercase in an inline block.
+
+```go
+Example using idp in a code block.
+```
+
+<!-- vale off -->
+Example using lowercase idp in vale-disabled block.
+<!-- vale on -->
+
+[idp-ref-link]: https://www.coop.no/


### PR DESCRIPTION
This will allow e.g. `[#team-idp](https://link.com/)` and `[#team-idp][slack-link]` 