### PR TITLE
feat: Add rule to create more descriptive link texts

### DIFF
--- a/Coop/.vale.ini
+++ b/Coop/.vale.ini
@@ -5,4 +5,4 @@ Vocab = CoopGeneral, CoopTech, CoopCompanies, CoopAbbreviations, CoopSystems, Co
 
 [*.md]
 TokenIgnores = [\w][\w.]*@[\w*][\w.]*[\w], <https://.+>, {{\sread_.+\(.+\)\s}}, \[.+\]\(.+\), \[.+\]\[.+\]
-BasedOnStyles = Vale
+BasedOnStyles = Vale, Coop

--- a/Coop/styles/Coop/MeaningfulLinkWords.yml
+++ b/Coop/styles/Coop/MeaningfulLinkWords.yml
@@ -1,0 +1,15 @@
+# Warning: Coop.MeaningfulLinkWords
+#
+# Checks for the presence of semantically unhelpful words in link text.
+#
+# For a list of all options, see https://vale.sh/docs/topics/styles/
+extends: existence
+message: "**Error**: Rewrite the link text for `%s` to be more descriptive."
+level: error
+ignorecase: true
+scope: raw
+nonword: true
+tokens:
+  - \[here\]\(.*\)
+  - \[this page\]\(.*\)
+  - \[read more\]\(.*\)


### PR DESCRIPTION
The more descriptive your link text, the easier it is for people to navigate
your site and for Google to understand what you are linking to.

Practically, this means you should avoid link text like `here`, `this page`, or
`read more`.
