### PR TITLE
feat: Add rule against punctuations at the end of headings

### DIFF
--- a/Coop/styles/Coop/HeadingPunctuation.yml
+++ b/Coop/styles/Coop/HeadingPunctuation.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "Don't put a period at the end of a heading."
+nonword: true
+level: error
+scope: heading
+action:
+  name: edit
+  params:
+    - trim_right
+    - "."
+tokens:
+  - '[a-z0-9][.]\s*$'


### PR DESCRIPTION
In document titles and headings, use sentence case. That is, capitalize only
the first word in the title, the first word in a subheading after a colon, and
any proper nouns or other terms that are always capitalized a certain way.

Even though you're using sentence case, don't put a period at the end of a
title or heading.
