### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-management.yaml
+++ b/.github/workflows/issue-management.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  issues: write
 name: Issue management
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/coopnorge/vale-coop/security/code-scanning/3](https://github.com/coopnorge/vale-coop/security/code-scanning/3)

To fix this issue, we need to add an explicit `permissions` block to restrict the `GITHUB_TOKEN` for this workflow according to the least privilege required for the actions performed. Since the job is handling issues and may need to read contents but only write to issues and possibly update project cards, we can add a minimal permissions block at either the root workflow level, or directly under the `handle-issues` job. The best approach for single-job workflows is to set it at the workflow root, which applies to all jobs unless overridden. Add the following block after the workflow name, specifying read-only permission on contents and write permission on issues:

```yaml
permissions:
  contents: read
  issues: write
```

If finer permissions are needed (e.g., to update project cards), those can be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
