### PR TITLE
chore: Add "Struct" and "struct" as accepted spellings to "STRUCT"

### DIFF
--- a/Coop/styles/config/vocabularies/CoopTech/accept.txt
+++ b/Coop/styles/config/vocabularies/CoopTech/accept.txt
@@ -54,6 +54,8 @@ README
 STDERR
 STDOUT
 STRUCT
+Struct
+struct
 Sekret
 SemVer
 ServiceEntry


### PR DESCRIPTION
Sometimes, we are talking about a Golang struct, and vale is currently complaining about it
